### PR TITLE
Merge pull request #1 from granatonatalia/copilot/fix-github-pages-lo…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,21 @@
+title: Terraform Intensivo
+description: Um guia prático e direto para profissionais que desejam dominar a arte de codificar infraestrutura.
+theme: jekyll-theme-primer
+
+# Prevent Liquid template errors from ${{ }} syntax in code examples
+liquid:
+  error_mode: warn
+
+# Exclude files that should not be processed by Jekyll
+exclude:
+  - CHANGELOG
+  - CODEOWNERS
+  - CONTRIBUTING.md
+  - MAINTENANCE.md
+  - SECURITY.md
+  - SUMMARY.md
+  - TERRAFORM.md
+  - LICENSE
+  - .coderabbit.yaml
+  - .github
+  - content/lives


### PR DESCRIPTION
## Problema

O build do **GitHub Pages (Jekyll)** estava falhando com erros. Pelos logs, o Jekyll iniciava o processamento do repositório, mas encontrava problemas durante a geração. Os principais pontos eram:

- **Ausência do `_config.yml`**: o Jekyll estava rodando com configurações padrão, o que pode causar comportamento imprevisível.
- **Conflitos com templates Liquid**: arquivos Markdown em `content/day-9/` (por exemplo, `PIPELINES.md` e `GITHUB-ACTIONS.md`) contêm a sintaxe de expressões do GitHub Actions como `${{ secrets.GITHUB_TOKEN }}`, que o Liquid do Jekyll tenta interpretar como variáveis de template.

## Correção

Foi adicionado um arquivo **`_config.yml`** com:

- **`title`** e **`description`**: metadados adequados do site.
- **`theme: jekyll-theme-primer`**: define explicitamente o tema que já estava sendo usado.
- **`liquid.error_mode: warn`**: altera erros do Liquid de *fatais* (quebram o build) para *warnings*, evitando que a sintaxe `${{ }}` em exemplos de código derrube o build.
- **Lista de `exclude`**: exclui arquivos que não são documentação (como `CHANGELOG`, `CODEOWNERS`, `CONTRIBUTING.md`, etc.) do processamento do Jekyll para manter o build mais limpo.

## Resumo de Segurança

Nenhuma vulnerabilidade de segurança foi introduzida. O `_config.yml` é um arquivo padrão de configuração do Jekyll e nenhum dado sensível foi commitado.